### PR TITLE
Release 1.5.0

### DIFF
--- a/Example/CocoaPods/Podfile.lock
+++ b/Example/CocoaPods/Podfile.lock
@@ -89,7 +89,7 @@ PODS:
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - JWTDecode (3.1.0)
-  - LucraSDK (1.4.1):
+  - LucraSDK (1.5.0):
     - Auth0
     - Resolver
     - ZendeskSupportSDK
@@ -159,7 +159,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 9abf64b682732fed36da827aa2a68f0221fd2356
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   JWTDecode: 3eaab1e06b6f4dcbdd6716aff09ba4c2104ca8b7
-  LucraSDK: 4630bb6ed1998308fc5ec59d0715eddaf8a2c06f
+  LucraSDK: 56494ffe6df0433a12030759712225f480d9eec1
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   Resolver: 0e2ce51257e9366c54afe1b9e9be25059e9b9300

--- a/LucraSDK.podspec
+++ b/LucraSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LucraSDK'
-    s.version          = '1.4.1'
+    s.version          = '1.5.0'
     s.summary          = 'LucraSDK for iOS'
 
     s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
 import PackageDescription
 
-let version = "1.4.1"
+let version = "1.5.0"
 
 let hostedPackageURL = "https://lucra-sdk.s3.amazonaws.com/ios/spm/\(version)"
 
@@ -34,17 +34,17 @@ let package = Package(
         .binaryTarget(
             name: "LucraSDK",
             url: "\(hostedPackageURL)/LucraSDK.xcframework.zip",
-            checksum: "4ebd6278635cd35d1e08cd7f1c6fd5c8b5a60e0356d1558b3ff6c108bab3deab"
+            checksum: "b00436a0b4f8fe20cca768f22effd2a76bb050e5706ecc3cd7712aff754ebb90"
         ),
         .binaryTarget(
             name: "MobileIntelligence",
             url: "\(hostedPackageURL)/MobileIntelligence.xcframework.zip",
-            checksum: "4c5d21a35c043325532e87c56a2d6ff66ec8c9dfdd0e0c7765fde80021cd0f54"
+            checksum: "600914784d5cdb54700633c90a6208e5a2eaa316b8a3196f54ed9b48d06c2fc1"
         ),
         .binaryTarget(
             name: "GeoComplySDK",
             url: "\(hostedPackageURL)/GeoComplySDK.xcframework.zip",
-            checksum: "60a8318777a83d3cf56b9f118d69ff349fb6a0926639b05c184165bb83ecb74b"
+            checksum: "9acff30eeff82ac4701850bba334292cd47f2e38a72e4b9711eee8062a3c6689"
         )
     ]
 )


### PR DESCRIPTION
• Ability to Edit Usernames - Users can now edit their usernames in their profile.
• Responsible Gaming - Users can now self-exclude themselves from depositing, creating, and accepting contests for a day, month, or year. Users can find this in the hamburger menu of the profile.
• New CAC CTA Sheet - We know launch a half sheet for tenants who have both SYW and GYP enabled that gives the user the option to select which contest they would like to create.
• Additional Withdrawal Screen Copy - We added copy to withdrawal screen to notify users that they must wait 3 days from their last deposit and play a contest in that time in order to withdraw.
• Added Codable Conformance to SportsMatchup and GamesMatchup models
• Removed Logging To OSLog if LucraLogging Callback Is Registered
• Various Bug Fixes and Improvements